### PR TITLE
Refactor cmd

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -2,46 +2,19 @@
 
 'use strict';
 
-const prog = require('caporal');
 const pkg = require('../package.json');
-const CompileCommand = require('../commands/compile');
-const GenerateCommand = require('../commands/generate');
+const prog = require('caporal');
+const Commands = require('../commands');
+const updateNotifier = require('update-notifier');
+
+updateNotifier({
+    pkg: pkg
+}).notify();
 
 prog
     .version(pkg.version)
-    .description(pkg.description)
-    .command('generate', 'Generate views from a JSON schema')
-    .argument('[source]', 'Path to directory with models', /.*/, GenerateCommand.DEFAULTS.source)
-    .argument('[output]', 'Filename for output.', /.*/, GenerateCommand.DEFAULTS.output)
-    .option('--clean', 'Should the contents of [source] be removed before running', prog.BOOL, GenerateCommand.DEFAULTS.options.clean)
-    .option('--save-gui-schema', 'Saves a copy of the intermediary GUI schema file', prog.BOOL, GenerateCommand.DEFAULTS.options.saveGuiSchema)
-    .option('--templates <path>', '<path> to template files', null, GenerateCommand.DEFAULTS.options.templates)
-    .action((args, options, logger) => {
+    .description(pkg.description);
 
-        const command = new GenerateCommand({
-            logger: logger
-        });
-
-        args.options = options;
-
-        command.execute(args).catch(logger.error);
-    });
-
-prog
-    .command('compile', 'Generate views from a GUI schema ')
-    .argument('[source]', 'Path to gui-schema', /.*/, CompileCommand.DEFAULTS.source)
-    .argument('[output]', 'Filename for output.', /.*/, CompileCommand.DEFAULTS.output)
-    .option('--clean', 'Should the contents of [source] be removed before running', prog.BOOL, CompileCommand.DEFAULTS.options.clean)
-    .option('--templates <path>', '<path> to template files', null, CompileCommand.DEFAULTS.options.templates)
-    .action((args, options, logger) => {
-
-        const command = new CompileCommand({
-            logger: logger
-        });
-
-        args.options = options;
-
-        command.execute(args).catch(logger.error);
-    });
+Commands.attach(prog);
 
 prog.parse(process.argv);

--- a/commands/base.js
+++ b/commands/base.js
@@ -1,0 +1,108 @@
+'use strict';
+const extend = require('gextend');
+// const Paths = require('../lib/cli-paths');
+const ChildProcess = require('child-process-promise');
+
+class BaseCommand {
+
+    constructor(options){
+        this.logger = options.logger || console;
+        // this.paths = new Paths();
+    }
+
+    execute(args){
+        return new Promise((resolve, reject)=>{
+            reject('Not implemented');
+        });
+    }
+
+    ready(){
+        if(this.useSudo) {
+            if(process.env.USER !== 'root'){
+                this.error('This command must run via sudo.');
+            } else if(!process.env.SUDO_USER || process.env.USER === process.env.SUDO_USER) {
+                this.error('This command must run via sudo, not as root.');
+            }
+        } else if(process.env.USER === 'root') {
+            this.error('This command cant be run as root.');
+        }
+
+        return this;
+    }
+
+    commandExists(command){
+        return ChildProcess.exec(`/usr/bin/which ${command}`)
+            .then(() => true)
+            .catch(() => false);
+    }
+
+    exec(command, options){
+        if(this.dryRun){
+            return this.logger.info(command, options);
+        }
+        return ChildProcess.exec(command, options);
+    }
+
+    execAsUser(command, options){
+        if(process.env.USER !== 'root'){
+            return this.exec(command, options);
+        }
+
+        return this.exec(`sudo -u "${process.env.SUDO_USER}" ${command}`, options);
+    }
+
+    error(msg, code=1){
+        this.logger.error(msg);
+        process.exit(code);
+    }
+
+    get useSudo(){
+        return !!this._sudo;
+    }
+
+    set useSudo(v){
+        this._sudo = v;
+    }
+
+    get dryRun(){
+        return !!this._dryRun;
+    }
+
+    set dryRun(v){
+        this._dryRun = v;
+    }
+
+    static attach(prog, namespace=false){
+        const name = (namespace ? namespace + ' ' : '') + this.COMMAND_NAME; 
+        
+        const cmd = prog.command(name, this.DESCRIPTION);
+
+        this.describe(prog, cmd);
+        
+        this.runner(cmd);
+    }
+
+    static describe(prog, cmd){}
+
+    static runner(cmd){
+        
+        const Command = this;
+
+        cmd.action((args, options, logger) => {
+            const command = new Command({
+                logger: logger
+            });
+
+            args.options = options;
+
+            command.ready()
+                .execute(args)
+                .then((context) => {
+                    process.exit(0);
+                })
+                .catch(logger.error);
+        });
+    }
+}
+
+module.exports = BaseCommand;

--- a/commands/compile.js
+++ b/commands/compile.js
@@ -1,15 +1,12 @@
 'use strict';
 const extend = require('gextend');
+const BaseCommand = require('./base');
 const clean = require('../lib/task-clean');
 const generate = require('../lib/generator').generateFromGUISchema;
 const readFile = require('fs').readFile;
 const resolve = require('path').resolve;
 
-class CompileCommand {
-
-    constructor(options = {}) {
-        extend(this, options);
-    }
+class CompileCommand extends BaseCommand {
 
     execute(event) {
         event = extend({}, CompileCommand.DEFAULTS, event);
@@ -47,6 +44,30 @@ class CompileCommand {
             });
         });
     }
+    static describe(prog, cmd){
+        cmd.argument('[source]', 
+            'Path to gui-schema', 
+            /.*/, 
+            CompileCommand.DEFAULTS.source
+        );
+
+        cmd.argument('[output]', 'Filename for output.', 
+            /.*/, 
+            CompileCommand.DEFAULTS.output
+        );
+
+        cmd.option('--clean', 
+            'Should the contents of [source] be removed before running', 
+            prog.BOOL, 
+            CompileCommand.DEFAULTS.options.clean
+        );
+
+        cmd.option('--templates <path>', 
+            '<path> to template files', 
+            null, 
+            CompileCommand.DEFAULTS.options.templates
+        );
+    }
 }
 
 CompileCommand.DEFAULTS = {
@@ -59,5 +80,8 @@ CompileCommand.DEFAULTS = {
         saveGuiSchema: false,
     }
 };
+
+CompileCommand.COMMAND_NAME = 'compile';
+CompileCommand.DESCRIPTION = 'Generate views from a GUI schema';
 
 module.exports = CompileCommand;

--- a/commands/generate.js
+++ b/commands/generate.js
@@ -1,15 +1,12 @@
 'use strict';
 const extend = require('gextend');
+const BaseCommand = require('./base');
 const clean = require('../lib/task-clean');
 const generate = require('../lib/generator');
 const readFile = require('fs').readFile;
 const resolve = require('path').resolve;
 
-class GenerateCommand {
-
-    constructor(options = {}) {
-        extend(this, options);
-    }
+class GenerateCommand extends BaseCommand {
 
     execute(event) {
         event = extend({}, GenerateCommand.DEFAULTS, event);
@@ -48,6 +45,38 @@ class GenerateCommand {
             });
         });
     }
+
+    static describe(prog, cmd){
+        cmd.argument('[source]', 
+            'Path to directory with models', 
+            /.*/, 
+            GenerateCommand.DEFAULTS.source
+        );
+        
+        cmd.argument('[output]', 
+            'Filename for output.', 
+            /.*/, 
+            GenerateCommand.DEFAULTS.output
+        );
+        
+        cmd.option('--clean', 
+            'Should the contents of [source] be removed before running', 
+            prog.BOOL, 
+            GenerateCommand.DEFAULTS.options.clean
+        );
+        
+        cmd.option('--save-gui-schema', 
+            'Saves a copy of the intermediary GUI schema file', 
+            prog.BOOL, 
+            GenerateCommand.DEFAULTS.options.saveGuiSchema
+        );
+        
+        cmd.option('--templates <path>', 
+            '<path> to template files', 
+            null, 
+            GenerateCommand.DEFAULTS.options.templates
+        );
+    }
 }
 
 GenerateCommand.DEFAULTS = {
@@ -60,5 +89,8 @@ GenerateCommand.DEFAULTS = {
         saveGuiSchema: false,
     }
 };
+
+GenerateCommand.COMMAND_NAME = 'open';
+GenerateCommand.DESCRIPTION = 'Generate views from a JSON schema';
 
 module.exports = GenerateCommand;

--- a/commands/index.js
+++ b/commands/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const Compile = require('./compile');
+const Generate = require('./generate');
+
+module.exports.attach = function(prog, namespace=false) {
+    Compile.attach(prog, namespace);
+    Generate.attach(prog, namespace);
+};

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/goliatone/core.io-cli-view-generator#readme",
   "dependencies": {
     "caporal": "^0.5.0",
+    "child-process-promise": "^2.2.1",
     "expand-files": "^0.8.4",
     "fs-exists-promised": "^0.2.0",
     "gextend": "^0.3.0",
@@ -37,6 +38,7 @@
     "mkdir-promise": "^1.0.0",
     "pretty-camel": "0.0.8",
     "rmfr": "^1.0.2",
-    "swig": "^1.4.2"
+    "swig": "^1.4.2",
+    "update-notifier": "^2.3.0"
   }
 }


### PR DESCRIPTION
Big refactoring to enable integration of package with [core.io cli toolbelt][1] by exposing commands in a standard way so that they can be imported as subcommands from another package.

[1]: https://github.com/goliatone/core.io-cli