### PR TITLE
fix: only add reltype to array if it has items

### DIFF
--- a/lib/makeGUISchema.js
+++ b/lib/makeGUISchema.js
@@ -81,9 +81,11 @@ function makeElement({ field, prop, logger }) {
         case 'array':
             field.type = 'text';
             field.element = 'multiselect';
-            field.items = prop.items;
             field.subType = 'array';
-            field.relType = 'many-to-one';
+            if (prop.items) {
+                field.items = prop.items;
+                field.relType = 'many-to-one';
+            }
             break;
         case 'json':
             field.type = 'text';


### PR DESCRIPTION
Do no add `relType` if we do not have collections